### PR TITLE
Refactor: Centralize spell definitions for improved management

### DIFF
--- a/IX/data/spellTypes.js
+++ b/IX/data/spellTypes.js
@@ -1,0 +1,233 @@
+// IX/data/spellTypes.js - Centralized spell definitions
+
+export const spellTypes = {
+  // Guardian
+  defend: {
+    name: "Phalanx Stance",
+    passive: true,
+    effect: "defend",
+    description: "50% less damage from piercing attacks",
+    enabled: false,
+    requiredUpgrade: "phalanxStance",
+    pierceDamageReductionPercentage: 0.5
+  },
+  // Stalker
+  improvedBow: {
+    name: "Improved Range",
+    passive: true,
+    effect: "improvedBow",
+    description: "Gain attack range",
+    enabled: false,
+    requiredUpgrade: "astralString"
+  },
+  marksmanship: {
+    name: "Phantom Arrow",
+    passive: true,
+    effect: "marksmanship",
+    description: "+3 attack damage",
+    enabled: false,
+    requiredUpgrade: "phantomArrow"
+  },
+  // Weaver
+  purge: {
+    name: "Cleanse",
+    manaCost: 75,
+    cooldown: 5,
+    effect: "dispel",  // Changed from "purge" to "dispel" to match AbilitySystem switch case
+    description: "Dispels a target unit",
+    enabled: true
+  },
+  castLightningShield: {
+    name: "Storm Aegis",
+    manaCost: 100,
+    cooldown: 3,
+    effect: "castLightningShield",
+    description: "Creates a storm shield dealing AoE damage to the target any other enemy in range",
+    enabled: false,
+    requiredUpgrade: "stormAegis",
+    effectDuration: 15,
+    damagePerSecond: 20,
+    aoeRadius: 30,
+    splashDamageFactor: 0.5
+  },
+  castBloodlust: {
+    name: "Primal Fury",
+    manaCost: 0,
+    cooldown: 3,
+    effect: "castBloodlust",
+    description: "Buff friendly units with increased speed",
+    enabled: false,
+    requiredUpgrade: "primalFury",
+    aoeRadius: 300,
+    effectDuration: 15,
+    attackSpeedBonusPercentage: 0.4,
+    moveSpeedBonusPercentage: 0.25
+  },
+  // Leviathan
+  burningOil: {
+    name: "Inferno Payload",
+    passive: true,
+    effect: "burningOil",
+    description: "Each attack burns the ground for AoE damage",
+    enabled: false,
+    requiredUpgrade: "infernoPayload",
+    aoeRadius: 80,
+    effectDuration: 5,
+    damagePerSecond: 15
+  },
+  // Oracle
+  heal: {
+    name: "Divine Mending",
+    manaCost: 10,
+    cooldown: 1.2,
+    effect: "heal",
+    description: "Heals a friendly unit for 25 HP",
+    enabled: true,
+    healAmount: 25
+  },
+  castDispelMagic: {
+    name: "Arcane Nullification",
+    manaCost: 75,
+    cooldown: 10,
+    effect: "castDispelMagic",
+    description: "Area dispel in a 150 radius",
+    enabled: false,
+    requiredUpgrade: "arcaneNullification",
+    aoeRadius: 150
+  },
+  castInnerFire: {
+    name: "Soul Fortification",
+    manaCost: 35,
+    cooldown: 3,
+    effect: "castInnerFire",
+    description: "Buff friendly unit with armor and damage",
+    enabled: false,
+    requiredUpgrade: "soulFortification",
+    effectDuration: 30,
+    armorBonus: 5,
+    damageBonusPercentage: 0.1
+  },
+  // Astral Nomad
+  spiritLink: {
+    name: "Soul Tether",
+    manaCost: 75,
+    cooldown: 15,
+    effect: "spiritLink",
+    description: "Links 4 friendly units to distribute 50% of damage received",
+    enabled: true,
+    aoeRadius: 300,
+    maxLinkedUnits: 4,
+    damageSharingPercentage: 0.5,
+    effectDuration: 45
+  },
+  castDisenchant: {
+    name: "Charm Breaker",
+    manaCost: 100,
+    cooldown: 10,
+    effect: "castDisenchant",
+    description: "Area dispel in a 120 radius",
+    enabled: false,
+    requiredUpgrade: "charmBreaker",
+    aoeRadius: 120
+  },
+  castAncestralSpirit: {
+    name: "Phantom Summons",
+    manaCost: 350,
+    cooldown: 30,
+    effect: "castAncestralSpirit",
+    description: "Resurrect a dead unit",
+    enabled: false,
+    requiredUpgrade: "phantomSummons",
+    resurrectableUnitTypes: ["juggernaut", "astralNomad"],
+    maxCorpseAgeSeconds: 60
+  },
+  // Marauder
+  ensnare: {
+    name: "Binding Chains",
+    manaCost: 0,
+    cooldown: 16,
+    effect: "ensnare",
+    description: "Temporarily binds an air unit to the ground",
+    enabled: true
+  },
+  pillage: {
+    name: "Plunder",
+    passive: true,
+    effect: "pillage",
+    description: "Gain 10 gold per attack on a building",
+    enabled: true,
+    goldPerHit: 10
+  },
+  // Trampler
+  devour: {
+    name: "Consumption",
+    cooldown: 20,
+    effect: "devour",
+    description: "Consumes an enemy unit over time",
+    enabled: true
+  },
+  warDrum: {
+    name: "Battle Cadence",
+    passive: true,
+    effect: "warDrum",
+    description: "Nearby friendly units gain 5% damage",
+    auraRange: 600,
+    enabled: true
+  },
+  warDrumUpgrade: {
+    name: "Resonant Echo",
+    passive: true,
+    effect: "warDrumUpgrade",
+    description: "Increases the damage bonus of Battle Cadence by 10%",
+    enabled: false,
+    requiredUpgrade: "resonantEcho"
+  },
+  // Juggernaut
+  pulverize: {
+    name: "Seismic Slam",
+    passive: true,
+    effect: "pulverize",
+    description: "25% chance to deal 60 AOE damage on attacks",
+    enabled: false,
+    requiredUpgrade: "seismicSlam",
+    procChance: 0.25,
+    aoeRadius: 60,
+    aoeDamage: 60
+  },
+  // Colossus
+  taunt: {
+    name: "Challenging Roar",
+    manaCost: 0,
+    cooldown: 15,
+    effect: "taunt",
+    description: "Nearby enemies are forced to attack this unit",
+    enabled: true,
+    aoeRadius: 250,
+    debuffDuration: 5
+  },
+  hardenSkin: {
+    name: "Crystalline Carapace",
+    passive: true,
+    effect: "hardenSkin",
+    description: "Reduces all attacks by 8 damage (minimum 3)",
+    enabled: false,
+    requiredUpgrade: "crystallineCarapace",
+    damageReductionAmount: 8,
+    minDamageTaken: 3
+  },
+  // Permafrost Drake
+  freezingBreath: {
+    name: "Glacial Tempest",
+    passive: true,
+    effect: "freezingBreath",
+    description: "Attacks stop buildings from attacking",
+    enabled: false,
+    requiredUpgrade: "glacialTempest",
+    stunDuration: 4
+  }
+};
+
+// Make spell types available globally
+if (typeof window !== 'undefined') {
+  window.spellTypes = spellTypes;
+}

--- a/IX/data/unitTypes.js
+++ b/IX/data/unitTypes.js
@@ -2,615 +2,554 @@
 
   // Define all unit types with their stats
   export const unitTypes = {
-    // TIER 1 UNITS
-    guardian: {
-      name: 'Guardian',
-      cost: 110,
-      requiredFortressLevel: 1,
-      stats: {
-        maxHealth: 220,
-        health: 220,
-        attackPower: {min: 12, max: 13},
-        attackType: 'normal',
-        attackRange: 35, // melee
-        attackSpeed: 0.88,
-        speed: 40,
-        armorType: 'heavy',
-        armorValue: 2,
-        color: "#73bed3", // Iridescent scale armor color
-        abilities: [
-          {
-            name: "Phalanx Stance",
-            passive: true,
-            effect: "defend",
-            description: "50% less damage from piercing attacks",
-            enabled: false,
-            requiredUpgrade: "phalanxStance",
-            pierceDamageReductionPercentage: 0.5
-          }
-        ],
-        possibleUpgrades: ['phalanxStance']
-      }
-    },
-    
-    stalker: {
-      name: 'Stalker',
-      cost: 160,
-      requiredFortressLevel: 1,
-      stats: {
-        maxHealth: 130,
-        health: 130,
-        attackPower: {min: 16, max: 18},
-        attackType: 'pierce',
-        attackRange: 85, //500
-        attackSpeed: 0.98,
-        speed: 40,
-        armorType: 'medium',
-        armorValue: 0,
-        color: "#8e44ad", // Purple for shadowy armor with glowing runes
-        abilities: [
-          {
-            name: "Improved Range",
-            passive: true,
-            effect: "improvedBow",
-            description: "Gain attack range",
-            enabled: false,
-            requiredUpgrade: "astralString"
-          },
-          {
-            name: "Phantom Arrow",
-            passive: true,
-            effect: "marksmanship",
-            description: "+3 attack damage",
-            enabled: false,
-            requiredUpgrade: "phantomArrow"
-          }
-        ],
-        possibleUpgrades: ['astralString', 'phantomArrow']
-      }
-    },
-    
-    weaver: {
-      name: 'Weaver',
-      cost: 140,
-      requiredFortressLevel: 1,
-      stats: {
-        maxHealth: 131,
-        health: 131,
-        maxMana: 200,
-        mana: 200,
-        attackPower: {min: 11, max: 13},
-        attackType: 'magic',
-        attackRange: 101, //600
-        attackSpeed: 1.37,
-        speed: 40,
-        armorType: 'unarmored',
-        armorValue: 0,
-        color: "#3498db", // Cosmic blue for luminescent markings
-        abilities: [
-          {
-            name: "Cleanse", 
-            manaCost: 75,
-            cooldown: 5,
-            effect: "purge", 
-            description: "Dispels a target unit",
-            enabled: true
-          },
-          {
-            name: "Storm Aegis",
-            manaCost: 100,
-            cooldown: 3,
-            effect: "castLightningShield",
-            description: "Creates a storm shield dealing AoE damage to the target any other enemy in range",
-            enabled: false,
-            requiredUpgrade: "stormAegis",
-            effectDuration: 15,
-            damagePerSecond: 20,
-            aoeRadius: 30,
-            splashDamageFactor: 0.5 
-          },
-          {
-            name: "Primal Fury",
-            manaCost: 0, 
-            cooldown: 3,
-            effect: "castBloodlust",
-            description: "Buff friendly units with increased speed",
-            enabled: false,
-            requiredUpgrade: "primalFury",
-            aoeRadius: 300,
-            effectDuration: 15,
-            attackSpeedBonusPercentage: 0.4,
-            moveSpeedBonusPercentage: 0.25
-          }
-        ],
-        possibleUpgrades: ['stormAegis', 'primalFury']
-      }
-    },
-    
-    // TIER 2 UNITS (Fortress Level 2)
-    leviathan: {
-      name: 'Leviathan',
-      cost: 300,
-      requiredFortressLevel: 2,
-      stats: {
-        maxHealth: 166,
-        health: 166,
-        attackPower: {min: 49, max: 53},
-        attackType: 'siege',
-        attackRange: 120, //800
-        attackSpeed: 3.54,
-        speed: 30,
-        armorType: 'heavy',
-        armorValue: 2,
-        color: "#e74c3c", // Fiery red for the glowing furnace eyes
-        abilities: [
-          {
-            name: "Inferno Payload",
-            passive: true,
-            effect: "burningOil",
-            description: "Each attack burns the ground for AoE damage",
-            enabled: false,
-            requiredUpgrade: "infernoPayload",
-            aoeRadius: 80,
-            effectDuration: 5,
-            damagePerSecond: 15
-          }
-        ],
-        possibleUpgrades: ['infernoPayload']
-      }
-    },
-    
-    oracle: {
-      name: 'Oracle',
-      cost: 160,
-      requiredFortressLevel: 2,
-      stats: {
-        maxHealth: 113,
-        health: 113,
-        maxMana: 200,
-        mana: 200,
-        attackPower: {min: 11, max: 13},
-        attackType: 'magic',
-        attackRange: 101,//600
-        attackSpeed: 1.30,
-        speed: 40,
-        armorType: 'unarmored',
-        armorValue: 0,
-        color: "#f1c40f", // Gold for sacred geometry patterns
-        abilities: [
-          {
-            name: "Divine Mending",
-            manaCost: 10,
-            cooldown: 1.2,
-            effect: "heal",
-            description: "Heals a friendly unit for 25 HP",
-            enabled: true,
-            healAmount: 25
-          },
-          {
-            name: "Arcane Nullification",
-            manaCost: 75,
-            cooldown: 10,
-            effect: "castDispelMagic",
-            description: "Area dispel in a 150 radius",
-            enabled: false,
-            requiredUpgrade: "arcaneNullification",
-            aoeRadius: 150
-          },
-          {
-            name: "Soul Fortification",
-            manaCost: 35,
-            cooldown: 3,
-            effect: "castInnerFire",
-            description: "Buff friendly unit with armor and damage",
-            enabled: false,
-            requiredUpgrade: "soulFortification",
-            effectDuration: 30,
-            armorBonus: 5,
-            damageBonusPercentage: 0.1
-          }
-        ],
-        possibleUpgrades: ['arcaneNullification', 'soulFortification']
-      }
-    },
-    
-    astralNomad: {
-      name: 'Astral Nomad',
-      cost: 170,
-      requiredFortressLevel: 2,
-      stats: {
-        maxHealth: 196,
-        health: 196,
-        maxMana: 300,
-        mana: 300,
-        attackPower: {min: 17, max: 22},
-        attackType: 'magic',
-        attackRange: 101,//600
-        attackSpeed: 1.13,
-        speed: 40,
-        armorType: 'unarmored',
-        armorValue: 0,
-        color: "#9b59b6", // Purple for celestial symbols
-        abilities: [
-          {
-            name: "Soul Tether",
-            manaCost: 75,
-            cooldown: 15,
-            effect: "spiritLink",
-            description: "Links 4 friendly units to distribute 50% of damage received",
-            enabled: true,
-            aoeRadius: 300,
-            maxLinkedUnits: 4,
-            damageSharingPercentage: 0.5,
-            effectDuration: 45
-          },
-          {
-            name: "Charm Breaker",
-            manaCost: 100,
-            cooldown: 10,
-            effect: "castDisenchant",
-            description: "Area dispel in a 120 radius",
-            enabled: false,
-            requiredUpgrade: "charmBreaker",
-            aoeRadius: 120
-          },
-          {
-            name: "Phantom Summons",
-            manaCost: 350,
-            cooldown: 30,
-            effect: "castAncestralSpirit",
-            description: "Resurrect a dead unit",
-            enabled: false,
-            requiredUpgrade: "phantomSummons",
-            resurrectableUnitTypes: ["juggernaut", "astralNomad"],
-            maxCorpseAgeSeconds: 60
-          }
-        ],
-        possibleUpgrades: ['charmBreaker', 'phantomSummons']
-      }
-    },
-    
-    marauder: {
-      name: 'Marauder',
-      cost: 160,
-      requiredFortressLevel: 2,
-      stats: {
-        maxHealth: 335,
-        health: 335,
-        attackPower: {min: 23, max: 27},
-        attackType: 'siege',
-        attackRange: 35, // melee
-        attackSpeed: 1.20,
-        speed: 50,
-        armorType: 'medium',
-        armorValue: 0,
-        color: "#c0392b", // Crimson accents on obsidian armor
-        abilities: [
-          {
-            name: "Binding Chains", 
-            manaCost: 0,
-            cooldown: 16,
-            effect: "ensnare",
-            description: "Temporarily binds an air unit to the ground",
-            enabled: true
-          }, 
-          {
-            name: "Plunder",
-            passive: true,
-            effect: "pillage",
-            description: "Gain 10 gold per attack on a building",
-            enabled: true,
-            goldPerHit: 10
-          }
-        ],
-        possibleUpgrades: []
-      }
-    },
-    
-    trampler: {
-      name: 'Trampler',
-      cost: 270,
-      requiredFortressLevel: 2,
-      stats: {
-        maxHealth: 490,
-        health: 490,
-        attackPower: {min: 16, max: 20},
-        attackType: 'pierce',
-        attackRange: 90,//500
-        attackSpeed: 0.94,
-        speed: 35,
-        armorType: 'unarmored',
-        armorValue: 1,
-        color: "#795548", // Earthy brown for tribal markings
-        abilities: [
-          {
-            name: "Consumption", 
-            cooldown: 20,
-            effect: "devour",
-            description: "Consumes an enemy unit over time",
-            enabled: true
-          }, 
-          {
-            name: "Battle Cadence", 
-            passive: true,
-            effect: "warDrum",
-            description: "Nearby friendly units gain 5% damage",
-            auraRange: 600,
-            enabled: true
-          },
-          {
-            name: "Resonant Echo", 
-            passive: true,
-            effect: "warDrumUpgrade", 
-            description: "Increases the damage bonus of Battle Cadence by 10%",
-            enabled: false,
-            requiredUpgrade: "resonantEcho"
-          }
-        ],
-        possibleUpgrades: ['resonantEcho']
-      }
-    },
-    
-    // TIER 3 UNITS (Fortress Level 3)
-    juggernaut: {
-      name: 'Juggernaut',
-      cost: 300,
-      requiredFortressLevel: 3,
-      stats: {
-        maxHealth: 637,
-        health: 637,
-        attackPower: {min: 30, max: 36},
-        attackType: 'normal',
-        attackRange: 35, // melee
-        attackSpeed: 1.24,
-        speed: 40,
-        armorType: 'heavy',
-        armorValue: 3,
-        color: "#d35400", // Volcanic rock with molten veins
-        abilities: [
-          {
-            name: "Seismic Slam",
-            passive: true,
-            effect: "pulverize",
-            description: "25% chance to deal 60 AOE damage on attacks",
-            enabled: false,
-            requiredUpgrade: "seismicSlam",
-            procChance: 0.25,
-            aoeRadius: 60,
-            aoeDamage: 60
-          }
-        ],
-        possibleUpgrades: ['seismicSlam']
-      }
-    },
-    
-    colossus: {
-      name: 'Colossus',
-      cost: 310,
-      requiredFortressLevel: 3,
-      stats: {
-        maxHealth: 686,
-        health: 686,
-        attackPower: {min: 28, max: 40},
-        attackType: 'normal',
-        attackRange: 35, // melee
-        attackSpeed: 1.63,
-        speed: 35,
-        armorType: 'normal', 
-        armorValue: 0,
-        color: "#7f8c8d", // Stone-like gray with crystal accents
-        abilities: [
-          {
-            name: "Challenging Roar",
-            manaCost: 0,
-            cooldown: 15,
-            effect: "taunt",
-            description: "Nearby enemies are forced to attack this unit",
-            enabled: true,
-            aoeRadius: 250,
-            debuffDuration: 5
-          },
-          {
-            name: "Crystalline Carapace",
-            passive: true,
-            effect: "hardenSkin",
-            description: "Reduces all attacks by 8 damage (minimum 3)",
-            enabled: false,
-            requiredUpgrade: "crystallineCarapace",
-            damageReductionAmount: 8,
-            minDamageTaken: 3
-          }
-        ],
-        possibleUpgrades: ['crystallineCarapace']
-      }
-    },
-    
-    permafrostDrake: {
-      name: 'Permafrost Drake',
-      cost: 440,
-      requiredFortressLevel: 3,
-      stats: {
-        maxHealth: 650,
-        health: 650,
-        attackPower: {min: 85, max: 105},
-        attackType: 'magic',
-        attackRange: 85,//500
-        attackSpeed: 1.95,
-        speed: 45,
-        armorType: 'light',
-        armorValue: 1,
-        color: "#00bcd4", // Ice crystal blue
-        abilities: [
-          {
-            name: "Glacial Tempest",
-            passive: true,
-            effect: "freezingBreath",
-            description: "Attacks stop buildings from attacking",
-            enabled: false,
-            requiredUpgrade: "glacialTempest",
-            stunDuration: 4
-          }
-        ],
-        possibleUpgrades: ['glacialTempest']
-      }
-    },
-    
-    // Basic unit for legacy support
-    basic: {
-      name: 'Basic',
-      cost: 90,
-      requiredFortressLevel: 1,
-      stats: {
-        maxHealth: 165,
-        health: 165,
-        attackPower: {min: 13, max: 13},
-        attackType: 'normal',
-        attackRange: 35,
-        attackSpeed: 0.88,
-        speed: 40,
-        armorType: 'medium',
-        armorValue: 0,
-        color: "#602c2c",
-        abilities: []
-      }
-    },
-  };
+  "guardian": {
+    "name": "Guardian",
+    "cost": 110,
+    "requiredFortressLevel": 1,
+    "stats": {
+      "maxHealth": 220,
+      "health": 220,
+      "attackPower": {
+        "min": 12,
+        "max": 13
+      },
+      "attackType": "normal",
+      "attackRange": 35,
+      "attackSpeed": 0.88,
+      "speed": 40,
+      "armorType": "heavy",
+      "armorValue": 2,
+      "color": "#73bed3",
+      "abilities": [
+        {
+          "spellId": "defend",
+          "name": "Phalanx Stance",
+          "enabled": false,
+          "passive": true,
+          "requiredUpgrade": "phalanxStance"
+        }
+      ],
+      "possibleUpgrades": [
+        "phalanxStance"
+      ]
+    }
+  },
+  "stalker": {
+    "name": "Stalker",
+    "cost": 160,
+    "requiredFortressLevel": 1,
+    "stats": {
+      "maxHealth": 130,
+      "health": 130,
+      "attackPower": {
+        "min": 16,
+        "max": 18
+      },
+      "attackType": "pierce",
+      "attackRange": 85,
+      "attackSpeed": 0.98,
+      "speed": 40,
+      "armorType": "medium",
+      "armorValue": 0,
+      "color": "#8e44ad",
+      "abilities": [
+        {
+          "spellId": "improvedBow",
+          "name": "Improved Range",
+          "enabled": false,
+          "passive": true,
+          "requiredUpgrade": "astralString"
+        },
+        {
+          "spellId": "marksmanship",
+          "name": "Phantom Arrow",
+          "enabled": false,
+          "passive": true,
+          "requiredUpgrade": "phantomArrow"
+        }
+      ],
+      "possibleUpgrades": [
+        "astralString",
+        "phantomArrow"
+      ]
+    }
+  },
+  "weaver": {
+    "name": "Weaver",
+    "cost": 140,
+    "requiredFortressLevel": 1,
+    "stats": {
+      "maxHealth": 131,
+      "health": 131,
+      "maxMana": 200,
+      "mana": 200,
+      "attackPower": {
+        "min": 11,
+        "max": 13
+      },
+      "attackType": "magic",
+      "attackRange": 101,
+      "attackSpeed": 1.37,
+      "speed": 40,
+      "armorType": "unarmored",
+      "armorValue": 0,
+      "color": "#3498db",
+      "abilities": [
+        {
+          "spellId": "purge",
+          "name": "Cleanse",
+          "enabled": true
+        },
+        {
+          "spellId": "castLightningShield",
+          "name": "Storm Aegis",
+          "enabled": false
+        },
+        {
+          "spellId": "castBloodlust",
+          "name": "Primal Fury",
+          "enabled": false
+        }
+      ],
+      "possibleUpgrades": [
+        "stormAegis",
+        "primalFury"
+      ]
+    }
+  },
+  "leviathan": {
+    "name": "Leviathan",
+    "cost": 300,
+    "requiredFortressLevel": 2,
+    "stats": {
+      "maxHealth": 166,
+      "health": 166,
+      "attackPower": {
+        "min": 49,
+        "max": 53
+      },
+      "attackType": "siege",
+      "attackRange": 120,
+      "attackSpeed": 3.54,
+      "speed": 30,
+      "armorType": "heavy",
+      "armorValue": 2,
+      "color": "#e74c3c",
+      "abilities": [
+        {
+          "spellId": "burningOil",
+          "name": "Inferno Payload",
+          "enabled": false,
+          "passive": true,
+          "requiredUpgrade": "infernoPayload"
+        }
+      ],
+      "possibleUpgrades": [
+        "infernoPayload"
+      ]
+    }
+  },
+  "oracle": {
+    "name": "Oracle",
+    "cost": 160,
+    "requiredFortressLevel": 2,
+    "stats": {
+      "maxHealth": 113,
+      "health": 113,
+      "maxMana": 200,
+      "mana": 200,
+      "attackPower": {
+        "min": 11,
+        "max": 13
+      },
+      "attackType": "magic",
+      "attackRange": 101,
+      "attackSpeed": 1.3,
+      "speed": 40,
+      "armorType": "unarmored",
+      "armorValue": 0,
+      "color": "#f1c40f",
+      "abilities": [
+        {
+          "spellId": "heal",
+          "name": "Divine Mending",
+          "enabled": true
+        },
+        {
+          "spellId": "castDispelMagic",
+          "name": "Arcane Nullification",
+          "enabled": false
+        },
+        {
+          "spellId": "castInnerFire",
+          "name": "Soul Fortification",
+          "enabled": false
+        }
+      ],
+      "possibleUpgrades": [
+        "arcaneNullification",
+        "soulFortification"
+      ]
+    }
+  },
+  "astralNomad": {
+    "name": "Astral Nomad",
+    "cost": 170,
+    "requiredFortressLevel": 2,
+    "stats": {
+      "maxHealth": 196,
+      "health": 196,
+      "maxMana": 300,
+      "mana": 300,
+      "attackPower": {
+        "min": 17,
+        "max": 22
+      },
+      "attackType": "magic",
+      "attackRange": 101,
+      "attackSpeed": 1.13,
+      "speed": 40,
+      "armorType": "unarmored",
+      "armorValue": 0,
+      "color": "#9b59b6",
+      "abilities": [
+        {
+          "spellId": "spiritLink",
+          "name": "Soul Tether",
+          "enabled": true
+        },
+        {
+          "spellId": "castDisenchant",
+          "name": "Charm Breaker",
+          "enabled": false
+        },
+        {
+          "spellId": "castAncestralSpirit",
+          "name": "Phantom Summons",
+          "enabled": false
+        }
+      ],
+      "possibleUpgrades": [
+        "charmBreaker",
+        "phantomSummons"
+      ]
+    }
+  },
+  "marauder": {
+    "name": "Marauder",
+    "cost": 160,
+    "requiredFortressLevel": 2,
+    "stats": {
+      "maxHealth": 335,
+      "health": 335,
+      "attackPower": {
+        "min": 23,
+        "max": 27
+      },
+      "attackType": "siege",
+      "attackRange": 35,
+      "attackSpeed": 1.2,
+      "speed": 50,
+      "armorType": "medium",
+      "armorValue": 0,
+      "color": "#c0392b",
+      "abilities": [
+        {
+          "spellId": "ensnare",
+          "name": "Binding Chains",
+          "enabled": true
+        },
+        {
+          "spellId": "pillage",
+          "name": "Plunder",
+          "enabled": true,
+          "passive": true
+        }
+      ],
+      "possibleUpgrades": []
+    }
+  },
+  "trampler": {
+    "name": "Trampler",
+    "cost": 270,
+    "requiredFortressLevel": 2,
+    "stats": {
+      "maxHealth": 490,
+      "health": 490,
+      "attackPower": {
+        "min": 16,
+        "max": 20
+      },
+      "attackType": "pierce",
+      "attackRange": 90,
+      "attackSpeed": 0.94,
+      "speed": 35,
+      "armorType": "unarmored",
+      "armorValue": 1,
+      "color": "#795548",
+      "abilities": [
+        {
+          "spellId": "devour",
+          "name": "Consumption",
+          "enabled": true
+        },
+        {
+          "spellId": "warDrum",
+          "name": "Battle Cadence",
+          "enabled": true,
+          "passive": true
+        },
+        {
+          "spellId": "warDrumUpgrade",
+          "name": "Resonant Echo",
+          "enabled": false,
+          "passive": true,
+          "requiredUpgrade": "resonantEcho"
+        }
+      ],
+      "possibleUpgrades": [
+        "resonantEcho"
+      ]
+    }
+  },
+  "juggernaut": {
+    "name": "Juggernaut",
+    "cost": 300,
+    "requiredFortressLevel": 3,
+    "stats": {
+      "maxHealth": 637,
+      "health": 637,
+      "attackPower": {
+        "min": 30,
+        "max": 36
+      },
+      "attackType": "normal",
+      "attackRange": 35,
+      "attackSpeed": 1.24,
+      "speed": 40,
+      "armorType": "heavy",
+      "armorValue": 3,
+      "color": "#d35400",
+      "abilities": [
+        {
+          "spellId": "pulverize",
+          "name": "Seismic Slam",
+          "enabled": false,
+          "passive": true,
+          "requiredUpgrade": "seismicSlam"
+        }
+      ],
+      "possibleUpgrades": [
+        "seismicSlam"
+      ]
+    }
+  },
+  "colossus": {
+    "name": "Colossus",
+    "cost": 310,
+    "requiredFortressLevel": 3,
+    "stats": {
+      "maxHealth": 686,
+      "health": 686,
+      "attackPower": {
+        "min": 28,
+        "max": 40
+      },
+      "attackType": "normal",
+      "attackRange": 35,
+      "attackSpeed": 1.63,
+      "speed": 35,
+      "armorType": "normal",
+      "armorValue": 0,
+      "color": "#7f8c8d",
+      "abilities": [
+        {
+          "spellId": "taunt",
+          "name": "Challenging Roar",
+          "enabled": true
+        },
+        {
+          "spellId": "hardenSkin",
+          "name": "Crystalline Carapace",
+          "enabled": false,
+          "passive": true,
+          "requiredUpgrade": "crystallineCarapace"
+        }
+      ],
+      "possibleUpgrades": [
+        "crystallineCarapace"
+      ]
+    }
+  },
+  "permafrostDrake": {
+    "name": "Permafrost Drake",
+    "cost": 440,
+    "requiredFortressLevel": 3,
+    "stats": {
+      "maxHealth": 650,
+      "health": 650,
+      "attackPower": {
+        "min": 85,
+        "max": 105
+      },
+      "attackType": "magic",
+      "attackRange": 85,
+      "attackSpeed": 1.95,
+      "speed": 45,
+      "armorType": "light",
+      "armorValue": 1,
+      "color": "#00bcd4",
+      "abilities": [
+        {
+          "spellId": "freezingBreath",
+          "name": "Glacial Tempest",
+          "enabled": false,
+          "passive": true,
+          "requiredUpgrade": "glacialTempest"
+        }
+      ],
+      "possibleUpgrades": [
+        "glacialTempest"
+      ]
+    }
+  },
+  "basic": {
+    "name": "Basic",
+    "cost": 90,
+    "requiredFortressLevel": 1,
+    "stats": {
+      "maxHealth": 165,
+      "health": 165,
+      "attackPower": {
+        "min": 13,
+        "max": 13
+      },
+      "attackType": "normal",
+      "attackRange": 35,
+      "attackSpeed": 0.88,
+      "speed": 40,
+      "armorType": "medium",
+      "armorValue": 0,
+      "color": "#602c2c",
+      "abilities": []
+    }
+  }
+};
 
   // Define available upgrades
   export const unitUpgrades = {
-    // Guardian upgrades
-    phalanxStance: {
-      name: "Phalanx Stance",
-      cost: 100,
-      effect: "defend",
-      description: "50% less damage from piercing attacks",
-      requiredFortressLevel: 1
-    },
-    
-    // Stalker upgrades
-    astralString: {
-      name: "Astral String",
-      cost: 50,
-      effect: "improvedBow",
-      description: "Gain attack range",
-      requiredFortressLevel: 1,
-      statBoosts: {
-        attackRange: 35 // +100 range
-      }
-    },
-    
-    phantomArrow: {
-      name: "Phantom Arrow",
-      cost: 100,
-      effect: "marksmanship",
-      description: "+3 attack damage",
-      requiredFortressLevel: 3,
-      statBoosts: {
-        attackPowerBonus: 3 // +3 to min and max
-      }
-    },
-    
-    // Weaver upgrades
-    stormAegis: {
-      name: "Storm Aegis",
-      cost: 100,
-      effect: "lightningShield", 
-      description: "Forms a static shield around enemy unit, dealing 20 damage per sec",
-      requiredFortressLevel: 1
-    },
-    
-    primalFury: {
-      name: "Primal Fury",
-      cost: 100,
-      effect: "bloodlust", 
-      description: "Increase friendly units attack speed by 40% and move speed by 25%",
-      requiredFortressLevel: 3
-    },
-    
-    // Leviathan upgrades
-    infernoPayload: {
-      name: "Inferno Payload",
-      cost: 50,
-      effect: "burningOil",
-      description: "Each attack burns the ground for AoE damage",
-      requiredFortressLevel: 2
-    },
-    
-    // Oracle upgrades
-    arcaneNullification: {
-      name: "Arcane Nullification",
-      cost: 100,
-      effect: "dispelMagic",
-      description: "Removes all buffs from units in target area",
-      requiredFortressLevel: 2
-    },
-    
-    soulFortification: {
-      name: "Soul Fortification",
-      cost: 100,
-      effect: "innerFire",
-      description: "Increases armor by 5 and adds 10% damage buff",
-      requiredFortressLevel: 3
-    },
-    
-    // Astral Nomad upgrades
-    charmBreaker: {
-      name: "Charm Breaker",
-      cost: 100,
-      effect: "disenchant",
-      description: "Cast an AOE dispel",
-      requiredFortressLevel: 2
-    },
-    
-    phantomSummons: {
-      name: "Phantom Summons",
-      cost: 100,
-      effect: "ancestralSpirit",
-      description: "Raises a dead Juggernaut or Astral Nomad back to life",
-      requiredFortressLevel: 3
-    },
-    
-    // Trampler upgrades
-    resonantEcho: {
-      name: "Resonant Echo",
-      cost: 150,
-      effect: "warDrumUpgrade",
-      description: "Increases the damage bonus of Battle Cadence by 10%",
-      requiredFortressLevel: 3,
-      modifiesAbility: "warDrum",
-      abilityBoost: {
-        damageBonus: 10 
-      }
-    },
-    
-    // Juggernaut upgrades
-    seismicSlam: {
-      name: "Seismic Slam",
-      cost: 100,
-      effect: "pulverize",
-      description: "25% chance to deal 60 AOE damage on attacks",
-      requiredFortressLevel: 3
-    },
-    
-    // Colossus upgrades
-    crystallineCarapace: {
-      name: "Crystalline Carapace",
-      cost: 150,
-      effect: "hardenSkin",
-      description: "Reduces all attacks by 8 damage (minimum 3)",
-      requiredFortressLevel: 3
-    },
-    
-    // Permafrost Drake upgrades
-    glacialTempest: {
-      name: "Glacial Tempest",
-      cost: 100,
-      effect: "freezingBreath",
-      description: "Attacks stop buildings from attacking",
-      requiredFortressLevel: 3
+  "phalanxStance": {
+    "name": "Phalanx Stance",
+    "cost": 100,
+    "effect": "defend",
+    "description": "50% less damage from piercing attacks",
+    "requiredFortressLevel": 1
+  },
+  "astralString": {
+    "name": "Astral String",
+    "cost": 50,
+    "effect": "improvedBow",
+    "description": "Gain attack range",
+    "requiredFortressLevel": 1,
+    "statBoosts": {
+      "attackRange": 35
     }
-  };
+  },
+  "phantomArrow": {
+    "name": "Phantom Arrow",
+    "cost": 100,
+    "effect": "marksmanship",
+    "description": "+3 attack damage",
+    "requiredFortressLevel": 3,
+    "statBoosts": {
+      "attackPowerBonus": 3
+    }
+  },
+  "stormAegis": {
+    "name": "Storm Aegis",
+    "cost": 100,
+    "effect": "lightningShield",
+    "description": "Forms a static shield around enemy unit, dealing 20 damage per sec",
+    "requiredFortressLevel": 1
+  },
+  "primalFury": {
+    "name": "Primal Fury",
+    "cost": 100,
+    "effect": "bloodlust",
+    "description": "Increase friendly units attack speed by 40% and move speed by 25%",
+    "requiredFortressLevel": 3
+  },
+  "infernoPayload": {
+    "name": "Inferno Payload",
+    "cost": 50,
+    "effect": "burningOil",
+    "description": "Each attack burns the ground for AoE damage",
+    "requiredFortressLevel": 2
+  },
+  "arcaneNullification": {
+    "name": "Arcane Nullification",
+    "cost": 100,
+    "effect": "dispelMagic",
+    "description": "Removes all buffs from units in target area",
+    "requiredFortressLevel": 2
+  },
+  "soulFortification": {
+    "name": "Soul Fortification",
+    "cost": 100,
+    "effect": "innerFire",
+    "description": "Increases armor by 5 and adds 10% damage buff",
+    "requiredFortressLevel": 3
+  },
+  "charmBreaker": {
+    "name": "Charm Breaker",
+    "cost": 100,
+    "effect": "disenchant",
+    "description": "Cast an AOE dispel",
+    "requiredFortressLevel": 2
+  },
+  "phantomSummons": {
+    "name": "Phantom Summons",
+    "cost": 100,
+    "effect": "ancestralSpirit",
+    "description": "Raises a dead Juggernaut or Astral Nomad back to life",
+    "requiredFortressLevel": 3
+  },
+  "resonantEcho": {
+    "name": "Resonant Echo",
+    "cost": 150,
+    "effect": "warDrumUpgrade",
+    "description": "Increases the damage bonus of Battle Cadence by 10%",
+    "requiredFortressLevel": 3,
+    "modifiesAbility": "warDrum",
+    "abilityBoost": {
+      "damageBonus": 10
+    }
+  },
+  "seismicSlam": {
+    "name": "Seismic Slam",
+    "cost": 100,
+    "effect": "pulverize",
+    "description": "25% chance to deal 60 AOE damage on attacks",
+    "requiredFortressLevel": 3
+  },
+  "crystallineCarapace": {
+    "name": "Crystalline Carapace",
+    "cost": 150,
+    "effect": "hardenSkin",
+    "description": "Reduces all attacks by 8 damage (minimum 3)",
+    "requiredFortressLevel": 3
+  },
+  "glacialTempest": {
+    "name": "Glacial Tempest",
+    "cost": 100,
+    "effect": "freezingBreath",
+    "description": "Attacks stop buildings from attacking",
+    "requiredFortressLevel": 3
+  }
+};
 
   // Make unit types available globally
-  window.unitTypes = unitTypes;
-  window.unitUpgrades = unitUpgrades;
+  if (typeof window !== 'undefined') {
+    window.unitTypes = unitTypes;
+    window.unitUpgrades = unitUpgrades;
+  }

--- a/IX/entities.js
+++ b/IX/entities.js
@@ -1,4 +1,5 @@
 // IX/entities.js - Consolidated entity classes
+import { unitTypes } from './data/unitTypes.js'; // Import unitTypes
 
 // Base entity class
 export class Entity {
@@ -63,7 +64,7 @@ export class Unit extends Entity {
   
   initializeFromType(type) {
     // Load unit data from unitTypes config
-    const unitData = window.unitTypes[type];
+    const unitData = unitTypes[type]; // Use imported unitTypes
     if (!unitData || !unitData.stats) {
       console.error(`Invalid unit type: ${type}`);
       return;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/refactor_units.js
+++ b/refactor_units.js
@@ -1,0 +1,141 @@
+const fs = require('fs');
+const vm = require('vm');
+
+function parseJsFileContent(content, objectName) {
+  // Remove export and window assignment
+  let scriptContent = content.replace(/^export const \w+ = /, '');
+  scriptContent = scriptContent.replace(/window\.\w+ = \w+;\s*$/, '');
+  // Remove trailing commas if any before a closing brace or bracket
+  scriptContent = scriptContent.replace(/,\s*([}\]])/g, '$1');
+  
+  // Wrap in an object to make it a valid expression for eval
+  const context = {};
+  vm.createContext(context);
+  vm.runInContext(`${objectName} = ${scriptContent}`, context);
+  return context[objectName];
+}
+
+function stringifyObject(obj, indent = 2) {
+  // Basic stringifier, not perfect for comments or complex formatting
+  // but good enough for JS object literals.
+  // For more complex cases, a proper code generator (like escodegen) would be better.
+  // This will not preserve comments within the objects.
+  return JSON.stringify(obj, (key, value) => {
+    if (typeof value === 'function') {
+      return value.toString(); // Keep functions as strings if any (not expected here)
+    }
+    return value;
+  }, indent);
+}
+
+
+const spellTypesFilePath = process.argv[2];
+const unitTypesFilePath = process.argv[3];
+
+const spellTypesContent = fs.readFileSync(spellTypesFilePath, 'utf8');
+const unitTypesContent = fs.readFileSync(unitTypesFilePath, 'utf8');
+
+// Extracting the objects by finding their start and end
+// This is safer than regex for large, complex objects and avoids eval on the whole file.
+
+let spellTypesString = spellTypesContent.substring(spellTypesContent.indexOf('{'), spellTypesContent.lastIndexOf('}') + 1);
+let unitTypesString = unitTypesContent.substring(unitTypesContent.indexOf('export const unitTypes = {') + 'export const unitTypes = '.length , unitTypesContent.indexOf('};', unitTypesContent.indexOf('export const unitTypes = {')) + 1);
+let unitUpgradesString = unitTypesContent.substring(unitTypesContent.indexOf('export const unitUpgrades = {') + 'export const unitUpgrades = '.length, unitTypesContent.indexOf('};', unitTypesContent.indexOf('export const unitUpgrades = {'))+1);
+
+const spellTypes = eval('(' + spellTypesString + ')');
+const unitTypes = eval('(' + unitTypesString + ')');
+const unitUpgrades = eval('(' + unitUpgradesString + ')');
+
+
+const preservedKeys = ['name', 'enabled', 'passive', 'requiredUpgrade', 'effect', 'description'];
+
+for (const unitName in unitTypes) {
+  if (unitTypes.hasOwnProperty(unitName)) {
+    const unit = unitTypes[unitName];
+    if (unit.stats && unit.stats.abilities) {
+      const originalAbilities = unit.stats.abilities;
+      const newAbilities = [];
+
+      for (const originalAbility of originalAbilities) {
+        const spellId = originalAbility.effect;
+        const baseSpell = spellTypes[spellId];
+
+        if (!baseSpell) { // If not found in spellTypes (e.g. some passives), keep as is.
+          newAbilities.push(originalAbility);
+          continue;
+        }
+        
+        // Check if this is a passive ability that was genericized in spellTypes.js
+        // If originalAbility.passive is true AND baseSpell.passive is true, then it's a genericized passive.
+        // If originalAbility.passive is true but baseSpell.passive is not, it's likely a unit-specific passive, keep as is.
+        // However, the prompt said "If a passive ability was genericized into spellTypes.js, then it should be updated like other abilities."
+        // The creation of spellTypes.js used `effect` as key. So if `spellTypes[originalAbility.effect]` exists, it was "genericized".
+        // The only special handling for passives is to ensure 'passive' and 'requiredUpgrade' are copied.
+
+        let newAbility = { spellId: spellId };
+
+        // 1. Always copy 'name'
+        newAbility.name = originalAbility.name;
+
+        // 2. Always copy 'enabled' if it exists
+        if (originalAbility.hasOwnProperty('enabled')) {
+          newAbility.enabled = originalAbility.enabled;
+        }
+
+        // 3. Handle 'passive' and 'requiredUpgrade' for passive abilities
+        if (originalAbility.passive) {
+          newAbility.passive = true; // it is passive
+          if (originalAbility.hasOwnProperty('requiredUpgrade')) {
+             // Only copy requiredUpgrade if it's different from base or not in base
+            if (!baseSpell.hasOwnProperty('requiredUpgrade') || baseSpell.requiredUpgrade !== originalAbility.requiredUpgrade) {
+                 newAbility.requiredUpgrade = originalAbility.requiredUpgrade;
+            }
+            // If it's same as base, it will be omitted, which is fine.
+            // However, the prompt was: "If passive: true, also copy requiredUpgrade if it exists." - this implies always copying it.
+            // Let's stick to the "copy if different or not in base" for overrides for consistency.
+            // Re-evaluating: "passive: originalAbility.passive if it exists". "If passive: true, also copy requiredUpgrade if it exists."
+            // This sounds like these two should always be copied if present in original for passives.
+            // Let's adjust: if originalAbility.passive, then newAbility.passive = true.
+            // And if originalAbility.requiredUpgrade exists (and it's passive), newAbility.requiredUpgrade = originalAbility.requiredUpgrade.
+            // This means `requiredUpgrade` for passives will always appear in unitTypes if it was there originally.
+             newAbility.requiredUpgrade = originalAbility.requiredUpgrade; // Always copy for passive if present
+          }
+        }
+
+
+        // 4. For all other properties, copy if different from baseSpell or not in baseSpell
+        for (const key in originalAbility) {
+          if (originalAbility.hasOwnProperty(key)) {
+            if (key === 'spellId' || key === 'effect' || key === 'description' || key === 'name' || key === 'enabled' || (key === 'passive' && originalAbility.passive) || (key === 'requiredUpgrade' && originalAbility.passive && originalAbility.hasOwnProperty('requiredUpgrade'))) {
+              // Already handled or should be skipped
+              continue;
+            }
+
+            if (!baseSpell.hasOwnProperty(key) || JSON.stringify(baseSpell[key]) !== JSON.stringify(originalAbility[key])) {
+              newAbility[key] = originalAbility[key];
+            }
+          }
+        }
+        newAbilities.push(newAbility);
+      }
+      unit.stats.abilities = newAbilities;
+    }
+  }
+}
+
+// Reconstruct the file content
+let outputContent = `// units/unitTypes.js - Unit definitions with reimagined fantasy units
+
+  // Define all unit types with their stats
+  export const unitTypes = ${stringifyObject(unitTypes, 2)};
+
+  // Define available upgrades
+  export const unitUpgrades = ${stringifyObject(unitUpgrades, 2)};
+
+  // Make unit types available globally
+  window.unitTypes = unitTypes;
+  window.unitUpgrades = unitUpgrades;
+`;
+
+console.log(outputContent);
+process.exit(0); // ensure a clean exit for the bash tool

--- a/test_spell_system.js
+++ b/test_spell_system.js
@@ -1,0 +1,278 @@
+// test_spell_system.js
+
+// Mock GameEngine and its systems
+const mockEntityManager = {
+    getUnits: (playerId) => {
+        if (playerId) return mockEntityManager.units.filter(u => u.playerId === playerId);
+        return mockEntityManager.units || [];
+    },
+    units: [],
+    add: (entity) => mockEntityManager.units.push(entity),
+    get: (id) => mockEntityManager.units.find(u => u.id === id),
+};
+
+const mockVisualSystem = {
+    createEffect: (effectData) => {
+        // console.log(`VisualSystem: Creating effect ${effectData.type} at ${effectData.x}, ${effectData.y}`);
+        if (effectData.targetUnit) {
+            // console.log(`  Target: ${effectData.targetUnit.type}`);
+        }
+        return effectData; // Return for chaining or inspection if needed
+    },
+    createGroundEffect: (effectData) => {
+        // console.log(`VisualSystem: Creating ground effect ${effectData.type}`);
+    }
+};
+
+const mockPlayerManager = {
+    getAutoCastSettings: (unitType, playerId) => ({}), // Default to no auto-cast overrides
+    players: {
+        'player1': { gold: 1000, fortressLevel: 3, purchasedUpgrades: [] },
+        'player2': { gold: 1000, fortressLevel: 3, purchasedUpgrades: [] }
+    }
+};
+
+const mockWaveManager = {
+    applyUpgradesToUnit: (unit, player) => {} // No-op for these tests
+};
+
+
+const mockEngine = {
+    entities: mockEntityManager,
+    systems: {
+        get: (systemName) => {
+            if (systemName === 'visual') return mockVisualSystem;
+            if (systemName === 'ability') return mockEngine.abilitySystem; // Added for self-reference
+            return null;
+        }
+    },
+    players: mockPlayerManager.players, // For AbilitySystem -> castAncestralSpirit
+    waveManager: mockWaveManager,      // For AbilitySystem -> castAncestralSpirit
+    canvas: { width: 800, height: 600 }, // For MovementSystem if indirectly used
+    abilitySystem: null // Will be set after AbilitySystem is instantiated
+};
+
+
+// --- Test Script ---
+async function runTests() {
+    console.log("Starting Spell System Tests...");
+
+    // Dynamically import modules
+    let Unit, AbilitySystem, spellTypes, unitTypes;
+    try {
+        ({ Unit } = await import('./IX/entities.js'));
+        ({ AbilitySystem } = await import('./IX/gameSystems.js'));
+        ({ spellTypes } = await import('./IX/data/spellTypes.js'));
+        ({ unitTypes } = await import('./IX/data/unitTypes.js'));
+        console.log("Modules loaded successfully.");
+    } catch (e) {
+        console.error("Failed to load modules:", e);
+        process.exit(1);
+    }
+
+    // Setup AbilitySystem
+    const abilitySystem = new AbilitySystem(mockEngine);
+    mockEngine.abilitySystem = abilitySystem; // Allow ability system to find itself if needed
+
+    // --- Test Case 1: Basic Spell Invocation (Weaver - Cleanse) ---
+    console.log("\n--- Test Case 1: Basic Spell Invocation (Weaver - Cleanse) ---");
+    mockEntityManager.units = []; // Clear entities
+
+    const weaverData = JSON.parse(JSON.stringify(unitTypes.weaver)); // Deep copy
+    const mockWeaver = new Unit('weaver', 'player1', 0, 0); // Unit needs an ID
+    mockWeaver.id = 'weaver1';
+    mockWeaver.type = 'weaver'; // Ensure type is set for ability lookup if any system relies on it
+    mockWeaver.stats = weaverData.stats; // Copy stats block
+    mockWeaver.abilities = weaverData.stats.abilities.map(ab => ({ ...ab, cooldownRemaining: 0 })); // Deep copy abilities
+    mockWeaver.mana = 200;
+    mockWeaver.maxMana = 200;
+    mockWeaver.x = 50; mockWeaver.y = 50; // Position for range checks
+    mockEntityManager.units.push(mockWeaver);
+
+    const cleanseAbility = mockWeaver.abilities.find(a => a.name === 'Cleanse');
+    if (!cleanseAbility) {
+        console.error("Test Case 1 Failed: Cleanse ability not found on mock Weaver.");
+        return;
+    }
+    cleanseAbility.cooldownRemaining = 0; // Ensure off cooldown
+
+    const initialManaWeaver = mockWeaver.mana;
+    const expectedManaCostCleanse = spellTypes.purge.manaCost;
+    const expectedCooldownCleanse = spellTypes.purge.cooldown;
+
+    console.log(`Weaver initial mana: ${initialManaWeaver}, Cleanse manaCost from spellTypes: ${expectedManaCostCleanse}`);
+    
+    // Mock a target for cleanse (though cleanse itself might not require a unit target in useAbility if ground cast)
+    const mockTargetUnitCleanse = new Unit('basic', 'player2', 60, 60);
+    mockTargetUnitCleanse.id = 'target1';
+    mockTargetUnitCleanse.type = 'basic';
+    mockEntityManager.units.push(mockTargetUnitCleanse);
+
+    const successCleanse = abilitySystem.useAbility(mockWeaver, 'Cleanse', 60, 60, mockTargetUnitCleanse);
+
+    if (successCleanse) {
+        const manaUsedCleanse = initialManaWeaver - mockWeaver.mana;
+        const cooldownSetCleanse = cleanseAbility.cooldownRemaining;
+        console.log(`Cleanse used. Mana after: ${mockWeaver.mana}, Cooldown set: ${cooldownSetCleanse}`);
+
+        if (manaUsedCleanse === expectedManaCostCleanse) {
+            console.log("Test Case 1 (Mana): PASSED");
+        } else {
+            console.error(`Test Case 1 (Mana): FAILED. Expected mana used: ${expectedManaCostCleanse}, Actual: ${manaUsedCleanse}`);
+        }
+        if (cooldownSetCleanse === expectedCooldownCleanse) {
+            console.log("Test Case 1 (Cooldown): PASSED");
+        } else {
+            console.error(`Test Case 1 (Cooldown): FAILED. Expected cooldown: ${expectedCooldownCleanse}, Actual: ${cooldownSetCleanse}`);
+        }
+    } else {
+        console.error("Test Case 1: FAILED. useAbility returned false for Cleanse.");
+    }
+
+    // --- Test Case 2: Spell with Overridden Parameters (Weaver - Cleanse with temp override) ---
+    console.log("\n--- Test Case 2: Spell with Overridden Parameters (Weaver - Cleanse with temp override) ---");
+    mockEntityManager.units = []; // Clear entities
+    
+    const weaverDataOverride = JSON.parse(JSON.stringify(unitTypes.weaver));
+    const mockWeaverOverride = new Unit('weaver', 'player1', 0, 0);
+    mockWeaverOverride.id = 'weaverOverride1';
+    mockWeaverOverride.type = 'weaver';
+    mockWeaverOverride.stats = weaverDataOverride.stats;
+    mockWeaverOverride.abilities = weaverDataOverride.stats.abilities.map(ab => ({ ...ab, cooldownRemaining: 0 }));
+    mockWeaverOverride.mana = 200;
+    mockWeaverOverride.maxMana = 200;
+    mockWeaverOverride.x = 50; mockWeaverOverride.y = 50;
+    mockEntityManager.units.push(mockWeaverOverride);
+
+    const cleanseAbilityOverride = mockWeaverOverride.abilities.find(a => a.name === 'Cleanse');
+    if (!cleanseAbilityOverride) {
+        console.error("Test Case 2 Failed: Cleanse ability not found on mockWeaverOverride.");
+        return;
+    }
+    cleanseAbilityOverride.cooldownRemaining = 0;
+    
+    // Introduce the override
+    const overriddenManaCost = 50;
+    cleanseAbilityOverride.manaCost = overriddenManaCost; // This simulates an override defined in unitTypes.js
+                                                        // because effectiveSpell = { ...base, ...unitAbility }
+
+    const initialManaWeaverOverride = mockWeaverOverride.mana;
+    console.log(`Weaver (Override) initial mana: ${initialManaWeaverOverride}, Overridden Cleanse manaCost: ${overriddenManaCost}`);
+    
+    const mockTargetUnitCleanseOverride = new Unit('basic', 'player2', 60, 60);
+    mockTargetUnitCleanseOverride.id = 'target2';
+    mockTargetUnitCleanseOverride.type = 'basic';
+    mockEntityManager.units.push(mockTargetUnitCleanseOverride);
+
+    const successCleanseOverride = abilitySystem.useAbility(mockWeaverOverride, 'Cleanse', 60, 60, mockTargetUnitCleanseOverride);
+
+    if (successCleanseOverride) {
+        const manaUsedCleanseOverride = initialManaWeaverOverride - mockWeaverOverride.mana;
+        console.log(`Cleanse (Override) used. Mana after: ${mockWeaverOverride.mana}`);
+
+        if (manaUsedCleanseOverride === overriddenManaCost) {
+            console.log("Test Case 2 (Mana Override): PASSED");
+        } else {
+            console.error(`Test Case 2 (Mana Override): FAILED. Expected mana used: ${overriddenManaCost}, Actual: ${manaUsedCleanseOverride}`);
+        }
+    } else {
+        console.error("Test Case 2: FAILED. useAbility returned false for Cleanse (Override).");
+    }
+
+    // --- Test Case 3: Passive Ability (Juggernaut - Seismic Slam) ---
+    console.log("\n--- Test Case 3: Passive Ability (Juggernaut - Seismic Slam) ---");
+    mockEntityManager.units = [];
+
+    const juggernautData = JSON.parse(JSON.stringify(unitTypes.juggernaut));
+    const mockJuggernaut = new Unit('juggernaut', 'player1', 0, 0);
+    mockJuggernaut.id = 'juggernaut1';
+    mockJuggernaut.type = 'juggernaut';
+    mockJuggernaut.stats = juggernautData.stats;
+    mockJuggernaut.abilities = juggernautData.stats.abilities.map(ab => ({ ...ab }));
+    mockJuggernaut.x = 50; mockJuggernaut.y = 50;
+    mockEntityManager.units.push(mockJuggernaut);
+
+    const seismicSlamAbility = mockJuggernaut.abilities.find(a => a.name === 'Seismic Slam');
+    if (!seismicSlamAbility) {
+        console.error("Test Case 3 Failed: Seismic Slam ability not found on mock Juggernaut.");
+        return;
+    }
+    seismicSlamAbility.enabled = true; // Ensure passive is enabled for test
+    seismicSlamAbility.procChance = 1.0; // Guarantee proc for testing
+
+    const mockTargetPassive = new Unit('basic', 'player2', 60, 60);
+    mockTargetPassive.id = 'targetPassive1';
+    mockTargetPassive.type = 'basic';
+    mockTargetPassive.health = 100; // Target for AOE damage
+    mockTargetPassive.maxHealth = 100;
+    let damageTakenByTarget = 0;
+    mockTargetPassive.takeDamage = function(amount) { // Mock takeDamage
+        damageTakenByTarget += amount;
+        this.health -= amount;
+        // console.log(`MockTargetPassive took ${amount} damage. Current health: ${this.health}`);
+    };
+    mockEntityManager.units.push(mockTargetPassive);
+    
+    // Mock another unit for AOE
+    const mockOtherTargetPassive = new Unit('basic', 'player2', 70, 70); // Within 60 radius of (60,60) if target is (60,60)
+    mockOtherTargetPassive.id = 'otherTargetPassive1';
+    mockOtherTargetPassive.type = 'basic';
+    mockOtherTargetPassive.health = 100;
+    mockOtherTargetPassive.maxHealth = 100;
+    let damageTakenByOtherTarget = 0;
+    mockOtherTargetPassive.takeDamage = function(amount) {
+        damageTakenByOtherTarget += amount;
+        this.health -= amount;
+        // console.log(`MockOtherTargetPassive took ${amount} damage. Current health: ${this.health}`);
+    };
+    mockEntityManager.units.push(mockOtherTargetPassive);
+
+
+    console.log("Simulating Juggernaut attack to trigger Seismic Slam (procChance = 1.0)...");
+    // handleAttackAbilities(attacker, target, damage)
+    // Target for the main attack is mockTargetPassive.
+    // Seismic slam AOE should also hit mockOtherTargetPassive if primary target is mockTargetPassive.
+    const attackResults = abilitySystem.handleAttackAbilities(mockJuggernaut, mockTargetPassive, 100);
+
+    const seismicSlamEffect = attackResults.effects.find(e => e.type === 'seismicSlam');
+    const expectedAoeDamage = spellTypes.pulverize.aoeDamage; // 60
+
+    if (seismicSlamEffect) {
+        console.log("Test Case 3 (Effect Triggered): PASSED. Seismic Slam effect found in results.");
+        if (seismicSlamEffect.radius === spellTypes.pulverize.aoeRadius) {
+            console.log("Test Case 3 (Radius): PASSED.");
+        } else {
+            console.error(`Test Case 3 (Radius): FAILED. Expected ${spellTypes.pulverize.aoeRadius}, Got ${seismicSlamEffect.radius}`);
+        }
+        
+        // Check if the other unit took AOE damage
+        // Note: handleAttackAbilities applies AOE to units *other than the primary target*
+        if (damageTakenByOtherTarget === expectedAoeDamage) {
+             console.log(`Test Case 3 (AOE Damage on Other Unit): PASSED. Other unit took ${damageTakenByOtherTarget} damage.`);
+        } else {
+            console.error(`Test Case 3 (AOE Damage on Other Unit): FAILED. Expected ${expectedAoeDamage} AOE damage, other unit took ${damageTakenByOtherTarget}.`);
+        }
+        // The primary target (mockTargetPassive) does NOT take damage from Seismic Slam via handleAttackAbilities's AOE loop;
+        // it takes the main attack damage. The ability is an ON-ATTACK effect, not a self-damage.
+        // If the prompt meant to check if the main target also got hit by its own slam, that's a different interpretation.
+        // Based on the code: `enemyUnits.forEach(enemyUnit => enemyUnit.takeDamage(aoeDamage));` where enemyUnits excludes `target`.
+
+    } else {
+        console.error("Test Case 3 (Effect Triggered): FAILED. Seismic Slam effect NOT found.");
+    }
+    
+    // Test for non-refactored passive (if one exists).
+    // For now, assume all relevant passives are refactored or the logic handles it.
+    // The code in handleAttackAbilities/handleDefenseAbilities uses `effectivePassiveSpell`
+    // which defaults to `unitAbility` if no `spellId` or `baseSpell` is found.
+    // This means it inherently supports non-refactored passives by using their direct definitions.
+    console.log("\nTest Case 3 (Non-Refactored Passive): SKIPPED - Covered by default behavior. All passives should use their defined properties, generic or specific.");
+
+
+    console.log("\nSpell System Tests Finished.");
+}
+
+runTests().catch(e => {
+    console.error("Error during test execution:", e);
+    process.exit(1);
+});


### PR DESCRIPTION
This change decouples spell definitions from unit data to make spell editing and balancing easier.

Key changes:
- Introduced `IX/data/spellTypes.js` to store all generic spell definitions. Each spell is keyed by its `effect` string.
- Modified `IX/data/unitTypes.js` so that unit abilities now reference a `spellId` (the effect string) from `spellTypes.js`. Unit-specific parameters can override the generic spell definition.
- Refactored `IX/gameSystems.js` (`AbilitySystem`):
    - The system now loads spell data from `spellTypes.js`.
    - When a spell is cast or a passive ability is processed, an `effectiveSpell` object is created by merging the base spell definition with any unit-specific overrides.
    - All spell logic now uses this `effectiveSpell` object to access parameters like mana cost, cooldown, AOE radius, damage, etc.
- I ran some tests using a Node.js script (`test_spell_system.js`) to verify core functionality including:
    - Basic spell invocation.
    - Correct application of overridden spell parameters.
    - Correct functioning of passive abilities using the new system.
    - An inconsistency in a spell effect name ('purge' vs 'dispel' for the Cleanse spell) was identified and corrected in `spellTypes.js` during testing.

This refactoring provides a more organized and maintainable structure for managing spell data and logic.